### PR TITLE
Changed the reference from master to main

### DIFF
--- a/.github/workflows/apply-on-master.yml
+++ b/.github/workflows/apply-on-master.yml
@@ -30,5 +30,5 @@ jobs:
         run: terraform plan
 
       - name: Terraform apply
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/main'
         run: terraform apply -auto-approve


### PR DESCRIPTION
When I merged this branch, the Actions skipped the Terraform Apply command. I was wrong because the main branch in this repo is called "main" and not "master". Hope it works now. Thanks for your collaboration. :)